### PR TITLE
Skip reporting on manually triggered build

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/verifystatus/VerificationsPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/verifystatus/VerificationsPublisher.java
@@ -173,11 +173,19 @@ public class VerificationsPublisher extends Publisher {
             gerritConfig.getGerritHttpUserName(),
             gerritConfig.getGerritHttpPassword());
     GerritApi gerritApi = gerritRestApiFactory.create(authData);
+    int changeNumber;
+    int patchSetNumber;
     try {
-      int changeNumber = Integer.parseInt(
-          getEnvVar(build, listener, GERRIT_CHANGE_NUMBER_ENV_VAR_NAME));
-      int patchSetNumber = Integer.parseInt(
-          getEnvVar(build, listener, GERRIT_PATCHSET_NUMBER_ENV_VAR_NAME));
+      changeNumber = Integer.parseInt(
+        getEnvVar(build, listener, GERRIT_CHANGE_NUMBER_ENV_VAR_NAME));
+      patchSetNumber = Integer.parseInt(
+        getEnvVar(build, listener, GERRIT_PATCHSET_NUMBER_ENV_VAR_NAME));
+    } catch (NumberFormatException e) {
+      logMessage(listener, "jenkins.plugin.info.not.gerrit.triggered",
+      Level.INFO);
+      return;
+    }
+    try {
       VerifyStatusApi verifyStatusApi = gerritApi.changes().id(changeNumber)
           .revision(patchSetNumber).verifyStatus();
       logMessage(listener, "jenkins.plugin.connected.to.gerrit", Level.INFO,

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -7,3 +7,4 @@ jenkins.plugin.error.gerrit.restapi.off=RestAPI in Gerrit-Trigger settings must 
 jenkins.plugin.connected.to.gerrit=Connected to Gerrit: server name: %s. Change Number: %s, PatchSetNumber: %s
 jenkins.plugin.verification.sent=Verification has been sent
 jenkins.plugin.error.gerrit.sysenv.disabled=Systen Environment variable setting is disabled
+jenkins.plugin.info.not.gerrit.triggered=Job not triggered by gerrit, not posting verifications


### PR DESCRIPTION
If a job is not triggered by gerrit (no change id or patchset id),
do not fail with an exception, just skip reporting.